### PR TITLE
Improve editorconfig - and have dependabot updating GitHub actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,9 @@
-# EditorConfig is awesome: https://EditorConfig.org
-
-# top-most EditorConfig file
 root = true
 
 [*]
 indent_style = tab
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
-insert_final_newline = false
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
editorconfig has tabs - is this intended

I otherwise added the enforcement of newlines at the end of the file

And instruct dependabot to update GitHub actions.